### PR TITLE
Update cashflows.cpp

### DIFF
--- a/ql/cashflows/cashflows.cpp
+++ b/ql/cashflows/cashflows.cpp
@@ -848,7 +848,7 @@ namespace QuantLib {
 #endif
 
         Real npv = 0.0;
-        DiscountFactor discount = 1.0;
+        Time t = 0.0;
         Date lastDate = npvDate;
         const DayCounter& dc = y.dayCounter();
         for (Size i=0; i<leg.size(); ++i) {
@@ -861,8 +861,8 @@ namespace QuantLib {
                 amount = 0.0;
             }
 
-            DiscountFactor b = y.discountFactor(getStepwiseDiscountTime(leg[i], dc, npvDate, lastDate));
-            discount *= b;
+            t += getStepwiseDiscountTime(leg[i], dc, npvDate, lastDate);//******* added by me
+            DiscountFactor discount = y.discountFactor(t);
             lastDate = leg[i]->date();
 
             npv += amount * discount;


### PR DESCRIPTION
Modified the discount factor calculation per each coupon payment date to reference the whole time interval from valuation date to coupon payment date.
The prior incorrect implementation computed the discount factor of a given coupon by multiplying the discount factor applying to the earlier coupon payment date with the forward discount factor between the earlier coupon payment date and the given coupon payment date.
More details at [opened issue](https://github.com/lballabio/QuantLib/issues/571)